### PR TITLE
Fixes regression when Ember doesn't generate proxy controllers when using {{render}}

### DIFF
--- a/packages/ember-routing-htmlbars/lib/keywords/render.js
+++ b/packages/ember-routing-htmlbars/lib/keywords/render.js
@@ -126,7 +126,7 @@ export default {
     // choose name
     if (params.length > 1) {
       var factory = container.lookupFactory(controllerFullName) ||
-                    generateControllerFactory(container, controllerName);
+                    generateControllerFactory(container, controllerName, read(context));
 
       controller = factory.create({
         model: read(context),


### PR DESCRIPTION
Here is an app that shows the issue. In the app we can modify bower_components/ember/ember.debug.js with this fix to test:
https://github.com/ember-samples/render-legacy-controller-generation

Here is a twiddle where we can toggle between 1.12 and 1.13
https://ember-twiddle.com/df75fe63672f01c4bf5f8f4b8a35ffc7?openFiles=controllers.application.js%2C

@ebryn2 @zen-tmq is this a good idea? We manually fixed one place at Zenefits by explicitly generating the controller (see https://github.com/zenefits/yourPeople3/pull/6714), but we have 51 places where we use `{{render}}` passing either an object or an array. Likely most of those don't have an explicit controller so they will rely on the proxy behavior. 

Note that proxy controller generation when returning and object or array from a route's model hooks still works as it did in previous version since the context is passed for that case, see https://github.com/emberjs/ember.js/blob/fixes-render-controller-generation/packages/ember-routing/lib/system/generate_controller.js#67. See test to prove this: https://ember-twiddle.com/a23bfd0e4223cdcc762a5ecfb1097cac?fileTreeShown=false&openFiles=templates.something.hbs%2C&route=%2Fsomething 